### PR TITLE
Fix example run in 2503 Q1

### DIFF
--- a/2503/facit.org
+++ b/2503/facit.org
@@ -87,34 +87,15 @@ Assume $G = 6.674 × 10^{−11}$
 Example run:
 #+begin_example
 >>> escape(7.3e22, 1.7e6, 5000) # moon example
-Excess speed: 2394.1153345848056
+Excess speed: 4389.557126260675
 
 >>> escape(6e24, 5.6e6, 5000) # earth example
 The object won't escape
 #+end_example
 
 ** Answer
-#+begin_src python :results output
-  import math
-  G = 6.674e-11
-  def escape(M,r,V):
-     v2 = 2*G*M / r
-     e2 = V**2 - v2
-     if e2 > 0:
-         print("Excess speed:", math.sqrt(e2))
-     else:
-         print("The object won't escape")
 
-  # moon example
-  escape(7.3e22, 1.7e6, 5000)
-  # earth example
-  escape(6e24, 5.6e6, 5000)
-#+end_src
-
-#+RESULTS:
-: Excess speed: 4389.557126260675
-: The object won't escape
-
+#+include: q1.py src python
 
 * Q2 Single-Rotation (20 points)
 

--- a/2503/q1.py
+++ b/2503/q1.py
@@ -1,0 +1,15 @@
+import math
+G = 6.674e-11
+def escape(M,r,V):
+    v2 = 2*G*M / r
+    e2 = V**2 - v2
+    if e2 > 0:
+        print("Excess speed:", math.sqrt(e2))
+    else:
+        print("The object won't escape")
+
+# moon example
+escape(7.3e22, 1.7e6, 5000)
+
+# earth example
+escape(6e24, 5.6e6, 5000)

--- a/2510/general.org
+++ b/2510/general.org
@@ -60,7 +60,7 @@ place: =https://github.com/jyp/python-courses-exams=
 If you believe that a mistake happened when grading your submission,
 you can come to the exam review ('granskning'), which will take place
 
-- Date: Nov 17th
+- Date: Nov 7th
 - Time: 13 to 14
 - Location: EDIT-6217
 


### PR DESCRIPTION
The example run says the output should be:

```
Excess speed: 2394.1153345848056
```

but that is printing _v_, not _e_.

Also moved solution into separate file.
PDF not updated (still incorrect).